### PR TITLE
[FIX] Param naming for torch>.5

### DIFF
--- a/pyvarinf/vi.py
+++ b/pyvarinf/vi.py
@@ -255,10 +255,10 @@ class Variationalize(nn.Module):
                     None)
 
                 if learn_mean:
-                    self.register_parameter(prefix + '.' + name + '_mean',
+                    self.register_parameter(prefix + '_' + name + '_mean',
                                             dico[name].mean)
                 if learn_rho:
-                    self.register_parameter(prefix + '.' + name + '_rho',
+                    self.register_parameter(prefix + '_' + name + '_rho',
                                             dico[name].rho)
 
             to_erase.append(name)
@@ -269,7 +269,7 @@ class Variationalize(nn.Module):
         for mname, sub_module in module.named_children():
             sub_dico = OrderedDict()
             self._variationalize_module(sub_dico, sub_module,
-                                        prefix + ('.' if prefix else '') +
+                                        prefix + ('_' if prefix else '') +
                                         mname, zero_mean,
                                         learn_mean, learn_rho)
             dico[mname] = sub_dico


### PR DESCRIPTION
Bug was raising the following error:

```bash
Traceback (most recent call last):
  File "/home/diviyan/conda/lib/python3.6/site-packages/pyvarinf/vi.py", line 232, in __init__
    learn_mean, learn_rho)
  File "/home/diviyan/conda/lib/python3.6/site-packages/pyvarinf/vi.py", line 274, in _variationalize_module
    learn_mean, learn_rho)
  File "/home/diviyan/conda/lib/python3.6/site-packages/pyvarinf/vi.py", line 274, in _variationalize_module
    learn_mean, learn_rho)
  File "/home/diviyan/conda/lib/python3.6/site-packages/pyvarinf/vi.py", line 259, in _variationalize_module
    dico[name].mean)
  File "/home/diviyan/conda/lib/python3.6/site-packages/torch/nn/modules/module.py", line 138, in register_parameter
    raise KeyError("parameter name can't contain \".\"")
KeyError: 'parameter name can\'t contain "."'
```
Best,
Diviyan